### PR TITLE
Adds ordering to ssl setup and documentation change

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,5 @@ openSSL module as extension for chassis.io. See https://github.com/Chassis/Chass
 ## Caveats and known problems:
 
 1. I haven't tested with multisite.
-1. You'll have to add the `.cert` file in the root directory of Chassis to your keychain and set it to "Always trust" to avoid the red "your connection is not encrypted" message. Don't know how to do it on a Windows machine. Let me know :)
+1. You also need to modify the `wp-config.php` in the root directory and modify the `WP_SITEURL` and `WP_HOME` constants to use https instead of http
+1. You'll have to add the `.cert` file in the root directory of Chassis to your keychain and set it to "Always trust" (right click on it, Get Info) to avoid the red "your connection is not encrypted" message. Don't know how to do it on a Windows machine. Let me know :)

--- a/chassis.pp
+++ b/chassis.pp
@@ -1,13 +1,11 @@
-openssl::certificate::x509 { 'vagrant.local':
+openssl::certificate::x509 { $fqdn:
   country      => 'CH',
   organization => 'Example.com',
   commonname   => $fqdn,
-}
-
-
-file { '/vagrant/vagrant.local.cert':
+} ->
+file { "/vagrant/${fqdn}.cert":
 	ensure => present,
-	source => '/etc/ssl/certs/vagrant.local.crt',
+	source => "/etc/ssl/certs/${fqdn}.crt",
 	mode => '0644',
 }
 


### PR DESCRIPTION
Closes #4
- Makes sure that the key and cert files are created before it tries to copy one of them
- Adds extra info about how to set it up
