### PR TITLE
Set Subject Alternative Names in certificate

### DIFF
--- a/chassis.pp
+++ b/chassis.pp
@@ -2,6 +2,7 @@ openssl::certificate::x509 { $fqdn:
   country      => 'CH',
   organization => 'Example.com',
   commonname   => $fqdn,
+  altnames     => [ $fqdn ],
 } ->
 file { "/vagrant/${fqdn}.cert":
 	ensure => present,


### PR DESCRIPTION
Partially fixes #8. `modules/openssl/templates/cert.cnf.erb` also has to be updated for this to work correctly though.