### PR TITLE
Include all defined hosts in SAN list

### DIFF
--- a/chassis.pp
+++ b/chassis.pp
@@ -1,8 +1,10 @@
+$openssl_config = sz_load_config()
+
 openssl::certificate::x509 { $fqdn:
   country      => 'CH',
   organization => 'Example.com',
   commonname   => $fqdn,
-  altnames     => [ $fqdn ],
+  altnames     => $openssl_config[hosts],
 } ->
 file { "/vagrant/${fqdn}.cert":
 	ensure => present,


### PR DESCRIPTION
Include all hosts defined in `config.yaml` in the certificate request SAN.