### PR TITLE
Don't create the ${fqdn}.d directory in this ext

### DIFF
--- a/modules/openssl-nginx/manifests/init.pp
+++ b/modules/openssl-nginx/manifests/init.pp
@@ -5,7 +5,7 @@ class openssl-nginx {
 			require => Package['nginx']
 		}
 	}
-	
+
 	file { "/etc/nginx/sites-available/$fqdn.d/ssl":
 		content => template('openssl-nginx/site.nginx.conf.ssl.erb'),
 		require => File[ "/etc/nginx/sites-available/$fqdn.d" ],

--- a/modules/openssl-nginx/manifests/init.pp
+++ b/modules/openssl-nginx/manifests/init.pp
@@ -1,4 +1,11 @@
 class openssl-nginx {
+	if ( ! defined( File["/etc/nginx/sites-available/${name}.d"] ) ) {
+		file { "/etc/nginx/sites-available/$fqdn.d":
+			ensure => directory,
+			require => Package['nginx']
+		}
+	}
+	
 	file { "/etc/nginx/sites-available/$fqdn.d/ssl":
 		content => template('openssl-nginx/site.nginx.conf.ssl.erb'),
 		require => File[ "/etc/nginx/sites-available/$fqdn.d" ],

--- a/modules/openssl-nginx/manifests/init.pp
+++ b/modules/openssl-nginx/manifests/init.pp
@@ -1,9 +1,4 @@
 class openssl-nginx {
-	file { "/etc/nginx/sites-available/$fqdn.d":
-		ensure => directory,
-		require => Package['nginx']
-	}
-
 	file { "/etc/nginx/sites-available/$fqdn.d/ssl":
 		content => template('openssl-nginx/site.nginx.conf.ssl.erb'),
 		require => File[ "/etc/nginx/sites-available/$fqdn.d" ],


### PR DESCRIPTION
This directory should be added in core so other extensions can extend the nginx config, causes the catalog to fail otherwise.

Will depend on https://github.com/Chassis/Chassis/pull/441

Found this issue while trying to make an extension to add a custom `location` directive.