### PR TITLE
Update documentation for wp-config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,8 @@ openSSL module as extension for chassis.io. See https://github.com/Chassis/Chass
 1. Run `vagrant reload --provision` or just `vagrant up`
 1. Create or edit `local-config.php` in Chassis root and add/edit the following: (see also: https://github.com/Chassis/Chassis/blob/master/docs/config.rst)
 
-        ```
         define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/wp');
         define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST']);
-        ```
 
 1. Profit.
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,14 @@ openSSL module as extension for chassis.io. See https://github.com/Chassis/Chass
 
 1. Clone this into the `extensions` folder of your Chassis installation. Use recursive: `git clone --recursive https://github.com/javorszky/chassis-openssl.git` to get the submodule pulled in as well.
 1. Run `vagrant reload --provision` or just `vagrant up`
+1. Create or edit `local-config.php` in Chassis root and add/edit the following: (see also: https://github.com/Chassis/Chassis/blob/master/docs/config.rst)
+```
+define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/wp');
+define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST']);
+```
 1. Profit.
 
 ## Caveats and known problems:
 
 1. I haven't tested with multisite.
-1. You also need to modify the `wp-config.php` in the root directory and modify the `WP_SITEURL` and `WP_HOME` constants to use https instead of http
 1. You'll have to add the `.cert` file in the root directory of Chassis to your keychain and set it to "Always trust" (right click on it, Get Info) to avoid the red "your connection is not encrypted" message. Don't know how to do it on a Windows machine. Let me know :)

--- a/README.md
+++ b/README.md
@@ -6,10 +6,12 @@ openSSL module as extension for chassis.io. See https://github.com/Chassis/Chass
 1. Clone this into the `extensions` folder of your Chassis installation. Use recursive: `git clone --recursive https://github.com/javorszky/chassis-openssl.git` to get the submodule pulled in as well.
 1. Run `vagrant reload --provision` or just `vagrant up`
 1. Create or edit `local-config.php` in Chassis root and add/edit the following: (see also: https://github.com/Chassis/Chassis/blob/master/docs/config.rst)
-  ```
-  define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/wp');
-  define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST']);
-  ```
+
+        ```
+        define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/wp');
+        define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST']);
+        ```
+
 1. Profit.
 
 ## Caveats and known problems:

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ openSSL module as extension for chassis.io. See https://github.com/Chassis/Chass
 1. Clone this into the `extensions` folder of your Chassis installation. Use recursive: `git clone --recursive https://github.com/javorszky/chassis-openssl.git` to get the submodule pulled in as well.
 1. Run `vagrant reload --provision` or just `vagrant up`
 1. Create or edit `local-config.php` in Chassis root and add/edit the following: (see also: https://github.com/Chassis/Chassis/blob/master/docs/config.rst)
-```
-define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/wp');
-define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST']);
-```
+  ```
+  define('WP_SITEURL', 'https://' . $_SERVER['HTTP_HOST'] . '/wp');
+  define('WP_HOME', 'https://' . $_SERVER['HTTP_HOST']);
+  ```
 1. Profit.
 
 ## Caveats and known problems:


### PR DESCRIPTION
Update README.md to mention new-ish Chassis feature using local-config.php to preset constants before wp-config.php is loaded.

Fixes https://github.com/javorszky/chassis-openssl/issues/6